### PR TITLE
Have package.json point to fork repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 
   "repository": {
     "type": "git",
-    "url": "git://github.com/trentm/node-bunyan.git"
+    "url": "git://github.com/TakeScoop/node-bunyan.git"
   },
   "engines": ["node >=0.10.0"],
   "keywords": ["log", "logging", "log4j", "json", "bunyan"],


### PR DESCRIPTION
I'm probably going to move our usage of bunyan at @Sydsvenskan over to your fork – feeling the same need as you. I hope that's alright?

Had a bit of a hard time finding the repo as I had only bookmarked the npm page. This suggested change would solve that 👌 